### PR TITLE
Fix NODE_ENV for test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # React Safe Srcdoc Iframe
 
-> A component which applies guards to srcdoc iframes in order to provide a predictable and safe experience to the user. Compliments the `sandbox` native iframe attribute.
+> A component which applies guards to srcdoc iframes in order to provide a predictable and safe experience to the user. Complements the `sandbox` native iframe attribute.
 
 <p align="center">
   <img src="assets/react-safe-src-doc-iframe-logo.png" width="300"/>

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "module": "es/safe-src-doc-iframe.js",
   "scripts": {
     "lint": "eslint --fix --ext jsx --ext js src/",
-    "test": "NODE_ENV=test npm run lint && jest src/",
+    "test": "npm run lint && NODE_ENV=test jest src/",
     "build:dev": "BABEL_ENV=umd webpack --config webpack.dev.config.js",
     "build:dist": "BABEL_ENV=umd webpack --config webpack.prod.config.js",
     "build:es": "BABEL_ENV=es babel src --out-dir es --source-maps inline",


### PR DESCRIPTION
NODE_ENV was applying to `npm run lint` but not afterwards, example of the error this fixes:

```
      Jest encountered an unexpected token
      This usually means that you are trying to import a file which Jest cannot parse, e.g. it's not plain JavaScript.
      By default, if Jest sees a Babel config, it will use that to transform your files, ignoring "node_modules".
      Here's what you can do:
       • To have some of your "node_modules" files transformed, you can specify a custom "transformIgnorePatterns" in your config.
       • If you need a custom transformation specify a "transform" option in your config.
       • If you simply want to mock your non-JS modules (e.g. binary assets) you can stub them out with the "moduleNameMapper" config option.
      You'll find more details and examples of these config options in the docs:
      https://jestjs.io/docs/en/configuration.html
      Details:
        14 |   `;
        15 |
      > 16 |   const testIframe = () => <SafeSrcDocIframe title='some-title' srcDoc={ mockDocument } />;
           |                            ^
        17 |
        18 |   const renderShallowSafeframe = () => {
        19 |     return shallow(testIframe());
```

(Also fixed a small typo.)